### PR TITLE
Docs: Fix Counter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import { render } from "react-dom"
 function useCounter() {
   let [count, setCount] = useState(0)
   let decrement = () => setCount(count - 1)
-  let increment = () => setCount(count - 1)
+  let increment = () => setCount(count + 1)
   return { count, decrement, increment }
 }
 


### PR DESCRIPTION
Fixes the example where the increment function would subtract from `count` instead of add to it.