### PR TITLE
docs: fix example for Keeping Containers Small

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ function useCount() {
 let Count = createContainer(useCount)
 
 function useCounter() {
-  let [count, setCount] = Counter.useContainer()
+  let [count, setCount] = Count.useContainer()
   let decrement = () => setCount(count - 1)
   let increment = () => setCount(count + 1)
   let reset = () => setCount(0)


### PR DESCRIPTION
Fixes the example for the **Tip #2: Keep Containers Small** section where `Counter.useContainer` was used instead of `Count.useContainer`.