### PR TITLE
Export interfaces

### DIFF
--- a/src/unstated-next.tsx
+++ b/src/unstated-next.tsx
@@ -1,10 +1,10 @@
 import React from "react"
 
-interface ContainerProviderProps {
+export interface ContainerProviderProps {
 	children: React.ReactNode
 }
 
-interface Container<Value> {
+export interface Container<Value> {
 	Provider: React.ComponentType<ContainerProviderProps>
 	useContainer: () => Value
 }


### PR DESCRIPTION
The interfaces need to be exported so that users don't encounter TS4023 when exporting their state outside of files

ie `export const UserState = createContainer(useUserState);`