### PR TITLE
Added initialState, a Container.Provider prop that is passed to useHook

### DIFF
--- a/src/unstated-next.tsx
+++ b/src/unstated-next.tsx
@@ -1,19 +1,24 @@
 import React from "react"
 
-export interface ContainerProviderProps {
+export interface ContainerProviderProps<InitialState> {
 	children: React.ReactNode
+	initialState?: InitialState | null | undefined
 }
 
-export interface Container<Value> {
-	Provider: React.ComponentType<ContainerProviderProps>
+export interface Container<Value, InitialState> {
+	Provider: React.ComponentType<ContainerProviderProps<InitialState | null>>
 	useContainer: () => Value
 }
 
-export function createContainer<Value>(useHook: () => Value): Container<Value> {
+export function createContainer<Value, InitialState>(
+	useHook: (initialState: InitialState | null | undefined) => Value,
+): Container<Value, InitialState> {
 	let Context = React.createContext<Value | null>(null)
 
-	function Provider(props: ContainerProviderProps) {
-		let value = useHook()
+	function Provider(
+		props: ContainerProviderProps<InitialState | null | undefined>,
+	) {
+		let value = useHook(props.initialState)
 		return <Context.Provider value={value}>{props.children}</Context.Provider>
 	}
 
@@ -28,6 +33,8 @@ export function createContainer<Value>(useHook: () => Value): Container<Value> {
 	return { Provider, useContainer }
 }
 
-export function useContainer<Value>(container: Container<Value>): Value {
+export function useContainer<Value, InitialState>(
+	container: Container<Value, InitialState>,
+): Value {
 	return container.useContainer()
 }


### PR DESCRIPTION
While I love the minimalism of the new unstated-next api, it unfortunately appeared to not be able to fulfill one of my team's key use cases, the ability to instantiate container state with dynamic values. To allow for this use case, I added an optional prop that is given to `<Container.Provider >`, `initialState`. This is then passed to `useHook()` when the provider is instantiated, where you can use this value as needed when writing your custom hook. 

### Example use case:

```ts
interface UserContainerState{
  name:string
}

// Fallback state
const defaultState: UserContainerState = {name:"Unknown"}

export function useUserContainer(initialState:UserContainerState | null | undefined) {
  if(!initialState){
    initialState = defaultState
  }
  const [name, setName] = useState(initialState.name||"Unknown");

  return {name, setName };
}

const UserContainer = createContainer(useUserContainer);

const HomePage: React.FC = ()=>{
return (
<div>
        <h2>User 1</h2>
        <UserContainer.Provider initialState={{name:"Jim"}}> //userContainer.name will start as 'Jim'
          <UserConsumer/>
        </UserContainer.Provider>
        <h2>User 2</h2>
        <UserContainer.Provider >
          <UserConsumer/> //userContainer.name will start as 'unknown'
        </UserContainer.Provider>
      </div>
);
}
```

An alternative method for solving this problem would be to pass all props from `Container.Provider` to the `useHook`, which may be a solution that is a little less specifically tied to this particular use case.


I am new to both typescript and contributing to open source, so if I made a mistake in either, let me know and I will be happy to fix what I can.

