### PR TITLE
Fix useCallback optimization example

### DIFF
--- a/README-ru-ru.md
+++ b/README-ru-ru.md
@@ -479,8 +479,8 @@ function CounterDisplay(props) {
 ```js
 function useCounter() {
   let [count, setCount] = useState(0)
-  let decrement = useCallback(() => setCount(count - 1), [count])
-  let increment = useCallback(() => setCount(count + 1), [count])
+  let decrement = useCallback(() => setCount(count => count - 1), [])
+  let increment = useCallback(() => setCount(count => count + 1), [])
   return { count, decrement, increment }
 }
 

--- a/README-th-th.md
+++ b/README-th-th.md
@@ -479,8 +479,8 @@ function CounterDisplay(props) {
 ```js
 function useCounter() {
   let [count, setCount] = useState(0)
-  let decrement = useCallback(() => setCount(count - 1), [count])
-  let increment = useCallback(() => setCount(count + 1), [count])
+  let decrement = useCallback(() => setCount(count => count - 1), [])
+  let increment = useCallback(() => setCount(count => count + 1), [])
   return { count, decrement, increment }
 }
 

--- a/README-vi-vn.md
+++ b/README-vi-vn.md
@@ -478,8 +478,8 @@ function CounterDisplay(props) {
 ```js
 function useCounter() {
   let [count, setCount] = useState(0)
-  let decrement = useCallback(() => setCount(count - 1), [count])
-  let increment = useCallback(() => setCount(count + 1), [count])
+  let decrement = useCallback(() => setCount(count => count - 1), [])
+  let increment = useCallback(() => setCount(count => count + 1), [])
   return { count, decrement, increment }
 }
 

--- a/README-zh-cn.md
+++ b/README-zh-cn.md
@@ -478,8 +478,8 @@ function CounterDisplay(props) {
 ```js
 function useCounter() {
   let [count, setCount] = useState(0)
-  let decrement = useCallback(() => setCount(count - 1), [count])
-  let increment = useCallback(() => setCount(count + 1), [count])
+  let decrement = useCallback(() => setCount(count => count - 1), [])
+  let increment = useCallback(() => setCount(count => count + 1), [])
   return { count, decrement, increment }
 }
 

--- a/README.md
+++ b/README.md
@@ -480,8 +480,8 @@ function CounterDisplay(props) {
 ```js
 function useCounter() {
   let [count, setCount] = useState(0)
-  let decrement = useCallback(() => setCount(count - 1), [count])
-  let increment = useCallback(() => setCount(count + 1), [count])
+  let decrement = useCallback(() => setCount(count => count - 1), [])
+  let increment = useCallback(() => setCount(count => count + 1), [])
   return { count, decrement, increment }
 }
 


### PR DESCRIPTION
In the fixed example, identities of `decrement` and `increment` stay stable even if `count` value changes.