### PR TITLE
Optional Children Props

### DIFF
--- a/src/unstated-next.tsx
+++ b/src/unstated-next.tsx
@@ -2,7 +2,7 @@ import React from "react"
 
 export interface ContainerProviderProps<State = void> {
 	initialState?: State
-	children: React.ReactNode
+	children?: React.ReactNode
 }
 
 export interface Container<Value, State = void> {


### PR DESCRIPTION
<!--I think `children` optional property is better. -->

`React.Context.Provider` provides `ProviderProps` which has  optional children property.

```ts
interface ProviderProps<T> {
    value: T;
    children?: ReactNode;
}
```

So, I think better that `ContainerProviderProps` provides `props?.children`.

Besides this, a custom provider can be following.

```ts
const App = () => (
  <Providers
    providers={[
      // children is optional
      <Counter1.Provider />,
      <Counter2.Provider initialState={10} />,

      // children is required
      <Counter1.Provider>{}</Counter1.Provider>,
      <Counter2.Provider initialState={10}>{}</Counter2.Provider>,
    ]}
  >
    <Child />
  </Providers>
);
```
