### PR TITLE
Initialize context with symbol value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4126,7 +4126,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4147,12 +4148,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4167,17 +4170,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4294,7 +4300,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4306,6 +4313,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4320,6 +4328,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -4327,12 +4336,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -4351,6 +4362,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4431,7 +4443,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4443,6 +4456,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4528,7 +4542,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4564,6 +4579,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4583,6 +4599,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4626,12 +4643,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/src/unstated-next.tsx
+++ b/src/unstated-next.tsx
@@ -13,7 +13,7 @@ export interface Container<Value, State = void> {
 export function createContainer<Value, State = void>(
 	useHook: (initialState?: State) => Value,
 ): Container<Value, State> {
-	let EMPTY = {}
+	const EMPTY: unique symbol = Symbol()
 	let Context = React.createContext<Value | typeof EMPTY>(EMPTY)
 
 	function Provider(props: ContainerProviderProps<State>) {

--- a/src/unstated-next.tsx
+++ b/src/unstated-next.tsx
@@ -13,7 +13,8 @@ export interface Container<Value, State = void> {
 export function createContainer<Value, State = void>(
 	useHook: (initialState?: State) => Value,
 ): Container<Value, State> {
-	let Context = React.createContext<Value | undefined>(undefined)
+	let EMPTY = {}
+	let Context = React.createContext<Value | typeof EMPTY>(EMPTY)
 
 	function Provider(props: ContainerProviderProps<State>) {
 		let value = useHook(props.initialState)
@@ -22,9 +23,10 @@ export function createContainer<Value, State = void>(
 
 	function useContainer(): Value {
 		let value = React.useContext(Context)
-		if (value === undefined) {
+		if (value === EMPTY) {
 			throw new Error("Component must be wrapped with <Container.Provider>")
 		}
+		// @ts-ignore
 		return value
 	}
 

--- a/src/unstated-next.tsx
+++ b/src/unstated-next.tsx
@@ -13,7 +13,7 @@ export interface Container<Value, State = void> {
 export function createContainer<Value, State = void>(
 	useHook: (initialState?: State) => Value,
 ): Container<Value, State> {
-	let Context = React.createContext<Value | null>(null)
+	let Context = React.createContext<Value | undefined>(undefined)
 
 	function Provider(props: ContainerProviderProps<State>) {
 		let value = useHook(props.initialState)
@@ -22,7 +22,7 @@ export function createContainer<Value, State = void>(
 
 	function useContainer(): Value {
 		let value = React.useContext(Context)
-		if (value === null) {
+		if (value === undefined) {
 			throw new Error("Component must be wrapped with <Container.Provider>")
 		}
 		return value


### PR DESCRIPTION
## The problem
Sometimes, a user may want the context to return a `null` value (i.e. getting an authenticated user). Since the library throws an error if the context value is `null`, this is not currently possible.

## This solution
This PR updates the initial context value to be a unique `symbol`, so if the context value is `null`, it won't throw an error.
