### PR TITLE
Add withContainer hoc

### DIFF
--- a/src/unstated-next.tsx
+++ b/src/unstated-next.tsx
@@ -10,6 +10,9 @@ export interface ContainerProviderProps<State = void> {
 export interface Container<Value, State = void> {
 	Provider: React.ComponentType<ContainerProviderProps<State>>
 	useContainer: () => Value
+	withContainer: <P extends object>(
+		Component: React.ComponentType<P>,
+	) => (props: P) => React.ReactNode
 }
 
 export function createContainer<Value, State = void>(
@@ -30,7 +33,17 @@ export function createContainer<Value, State = void>(
 		return value
 	}
 
-	return { Provider, useContainer }
+	function withContainer<P extends object>(Component: React.ComponentType<P>) {
+		return (props: P) => {
+			return (
+				<Provider>
+					<Component {...props} />
+				</Provider>
+			)
+		}
+	}
+
+	return { Provider, useContainer, withContainer }
 }
 
 export function useContainer<Value, State = void>(


### PR DESCRIPTION
Here's a use case. I think the API would be really nice.

```
import { State } from './state.provider';

const Parent = () => {
    const { handleAction, currState, component: Component } = State.useContainer();
    
    return (
          <Component sendAction={handleAction} pollData={pollData} />
    );
};

export default State.withContainer(Parent);
```

Without the above, you need to do this everytime you create a new state:

```
import { State } from './state.provider';

const withContainer = (Component) => (props) => (
    <State.Provider>
        <Component {...props} />
    </State.Provider>
);

const Parent = () => {
    const { handleAction, currState, component: Component } = State.useContainer();
    
    return (
          <Component sendAction={handleAction} pollData={pollData} />
    );
};

export default withContainer(Parent);
```